### PR TITLE
RCAL-1075: use env variable for pickle model in roman_photoz.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,9 @@
 # Ignore __pycache__ directories
 *.py[cod]
 docs/_build/
+
+# IDE and editor specific configuration files
+pyrightconfig.json
+
+# Python package build artifacts
+roman_photoz.egg-info/

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ pyrightconfig.json
 
 # Python package build artifacts
 roman_photoz.egg-info/
+.tox/

--- a/docs/create_simulated_catalog.rst
+++ b/docs/create_simulated_catalog.rst
@@ -54,4 +54,3 @@ The following example demonstrates how to programmatically create a simulated ca
     )
 
     print(f"Simulated catalog with {len(catalog)} sources created successfully")
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,62 +4,63 @@ description = "Library for photometric redshift determination using data from th
 readme = "README.md"
 requires-python = ">=3.10"
 authors = [
-    { name = "Roman calibration pipeline developers", email = "help@stsci.edu" },
+  { name = "Roman calibration pipeline developers", email = "help@stsci.edu" },
 ]
 classifiers = [
-    "Intended Audience :: Science/Research",
-    "Topic :: Scientific/Engineering :: Astronomy",
-    "Programming Language :: Python :: 3",
+  "Intended Audience :: Science/Research",
+  "Topic :: Scientific/Engineering :: Astronomy",
+  "Programming Language :: Python :: 3",
 ]
 dependencies = [
-    "asdf >=3.3.0",
-    "asdf-astropy >=0.5.0",
-    "astropy >=5.3.0",
-    "crds >=11.16.16",
-    "gwcs >=0.21.0",
-    "jsonschema >=4.8",
-    "numpy >=1.23",
-    "photutils >=1.13.0",
-    "pyparsing >=2.4.7",
-    "requests >=2.26",
-    "roman_datamodels>=0.22.0",
-    # "roman_datamodels @ git+https://github.com/spacetelescope/roman_datamodels.git",
-    "scipy>=1.7.0",
-    "stcal>=1.10.0",
-    # "stcal @ git+https://github.com/spacetelescope/stcal.git@main",
-    "stpipe >=0.7.0",
-    # "stpipe @ git+https://github.com/spacetelescope/stpipe.git@main",
-    "tweakwcs >=0.8.8",
-    "spherical-geometry >= 1.2.22",
-    "stsci.imagestats >= 1.6.3",
-    "drizzle >= 1.15.0",
-    "webbpsf >= 1.2.1",
-    # "pz-rail-lephare",
-    "pz-rail-lephare @ git+https://git@github.com/mairanteodoro/rail_lephare.git",
-    "lephare == 0.1.13",
+  "asdf >=3.3.0",
+  "asdf-astropy >=0.5.0",
+  "astropy >=5.3.0",
+  "crds >=11.16.16",
+  "gwcs >=0.21.0",
+  "jsonschema >=4.8",
+  "numpy >=1.23",
+  "photutils >=1.13.0",
+  "pyparsing >=2.4.7",
+  "requests >=2.26",
+  "roman_datamodels>=0.22.0",
+  # "roman_datamodels @ git+https://github.com/spacetelescope/roman_datamodels.git",
+  "scipy>=1.7.0",
+  "stcal>=1.10.0",
+  # "stcal @ git+https://github.com/spacetelescope/stcal.git@main",
+  "stpipe >=0.7.0",
+  # "stpipe @ git+https://github.com/spacetelescope/stpipe.git@main",
+  "tweakwcs >=0.8.8",
+  "spherical-geometry >= 1.2.22",
+  "stsci.imagestats >= 1.6.3",
+  "drizzle >= 1.15.0",
+  "webbpsf >= 1.2.1",
+  # "pz-rail-lephare",
+  "pz-rail-lephare @ git+https://git@github.com/mairanteodoro/rail_lephare.git",
+  "lephare == 0.1.13",
+  "pz-rail-base == 1.1.5",
 ]
 license-files = ["LICENSE"]
 dynamic = ["version"]
 
 [project.optional-dependencies]
 docs = [
-    "matplotlib",
-    "sphinx",
-    "sphinx-astropy",
-    "sphinx-automodapi",
-    "sphinx-rtd-theme",
-    "stsci-rtd-theme",
-    "sphinx-autobuild",
-    "tomli; python_version <=\"3.11\"",
-    "sphinx-argparse",
+  "matplotlib",
+  "sphinx",
+  "sphinx-astropy",
+  "sphinx-automodapi",
+  "sphinx-rtd-theme",
+  "stsci-rtd-theme",
+  "sphinx-autobuild",
+  "tomli; python_version <=\"3.11\"",
+  "sphinx-argparse",
 ]
 test = [
-    "ci-watson >=0.5.0",
-    "pytest >8.0.0",
-    "pytest-astropy >= 0.11.0",
-    "deepdiff",
-    "stpreview>=0.5.1",
-    "pytest-cov",
+  "ci-watson >=0.5.0",
+  "pytest >8.0.0",
+  "pytest-astropy >= 0.11.0",
+  "deepdiff",
+  "stpreview>=0.5.1",
+  "pytest-cov",
 ]
 dev = ["roman_photoz[docs,test]", "tox > 4", "pre-commit > 3"]
 sdp = ["stpreview>=0.5.1"]
@@ -83,14 +84,14 @@ zip-safe = false
 [tool.setuptools.package-data]
 # package_data values are glob patterns relative to each specific subpackage.
 "*" = [
-    "**/*.fits",
-    "**/*.txt",
-    "**/*.inc",
-    "**/*.cfg",
-    "**/*.csv",
-    "**/*.yaml",
-    "**/*.json",
-    "**/*.asdf",
+  "**/*.fits",
+  "**/*.txt",
+  "**/*.inc",
+  "**/*.cfg",
+  "**/*.csv",
+  "**/*.yaml",
+  "**/*.json",
+  "**/*.asdf",
 ]
 
 [tool.pytest.ini_options]
@@ -120,7 +121,7 @@ line-length = 88
 [tool.ruff.lint]
 exclude = ["jdocs", ".tox", ".eggs", "build"]
 ignore = [
-    "E741", # ambiguous variable name
+  "E741", # ambiguous variable name
 ]
 extend-select = ["NPY"]
 
@@ -132,10 +133,7 @@ archs = ["auto", "aarch64"]
 
 [tool.coverage.run]
 source = ["roman_photoz"]
-omit = [
-    "*/tests/*",
-    "*/docs/*",
-]
+omit = ["*/tests/*", "*/docs/*"]
 
 [tool.coverage.report]
 show_missing = true

--- a/roman_photoz/roman_catalog_process.py
+++ b/roman_photoz/roman_catalog_process.py
@@ -22,10 +22,9 @@ from roman_photoz.roman_catalog_handler import RomanCatalogHandler
 DS = RailStage.data_store
 DS.__class__.allow_overwrite = True
 
-LEPHAREDIR = os.environ.get("LEPHAREDIR", lp.LEPHAREDIR)
-LEPHAREWORK = os.environ.get(
-    "LEPHAREWORK", (Path(LEPHAREDIR).parent / "work").as_posix()
-)
+LEPHAREDIR = Path(os.environ.get("LEPHAREDIR", lp.LEPHAREDIR))
+LEPHAREWORK = os.environ.get("LEPHAREWORK", (LEPHAREDIR / "work").as_posix())
+INFORMER_MODEL_PATH = os.environ.get("INFORMER_MODEL_PATH", LEPHAREWORK)
 # default paths and filenames
 DEFAULT_INPUT_FILENAME = "roman_simulated_catalog.asdf"
 DEFAULT_INPUT_PATH = LEPHAREWORK
@@ -75,7 +74,6 @@ class RomanCatalogProcess:
         self.set_config_file(config_filename)
         # set model filename
         self.model_filename = model_filename
-        self.informer_model_path = Path(LEPHAREWORK, self.model_filename).as_posix()
         # set attributes used for determining the redshift
         self.flux_cols: list = []
         self.flux_err_cols: list = []
@@ -334,6 +332,22 @@ class RomanCatalogProcess:
             )
             return True
         return False
+
+    @property
+    def informer_model_path(self):
+        """
+        Get the path to the informer model file.
+
+        The path is determined by checking the INFORMER_MODEL_PATH environment variable first,
+        falling back to LEPHAREWORK if not set.
+
+        Returns
+        -------
+        str
+            The path to the informer model file.
+        """
+        informer_path = os.environ.get("INFORMER_MODEL_PATH", os.environ.get("LEPHAREWORK", ""))
+        return Path(informer_path, self.model_filename).as_posix()
 
 
 def _get_parser():

--- a/roman_photoz/roman_catalog_process.py
+++ b/roman_photoz/roman_catalog_process.py
@@ -24,7 +24,7 @@ DS.__class__.allow_overwrite = True
 
 LEPHAREDIR = Path(os.environ.get("LEPHAREDIR", lp.LEPHAREDIR))
 LEPHAREWORK = os.environ.get("LEPHAREWORK", (LEPHAREDIR / "work").as_posix())
-INFORMER_MODEL_PATH = os.environ.get("INFORMER_MODEL_PATH", LEPHAREWORK)
+
 # default paths and filenames
 DEFAULT_INPUT_FILENAME = "roman_simulated_catalog.asdf"
 DEFAULT_INPUT_PATH = LEPHAREWORK

--- a/roman_photoz/roman_catalog_process.py
+++ b/roman_photoz/roman_catalog_process.py
@@ -346,7 +346,9 @@ class RomanCatalogProcess:
         str
             The path to the informer model file.
         """
-        informer_path = os.environ.get("INFORMER_MODEL_PATH", os.environ.get("LEPHAREWORK", ""))
+        informer_path = os.environ.get(
+            "INFORMER_MODEL_PATH", os.environ.get("LEPHAREWORK", "")
+        )
         return Path(informer_path, self.model_filename).as_posix()
 
 

--- a/roman_photoz/tests/test_create_roman_filters.py
+++ b/roman_photoz/tests/test_create_roman_filters.py
@@ -86,7 +86,7 @@ def test_read_effarea_file(file_exists, test_file, expected_kwargs, expected_dow
     """Test reading an efficiency area file, with or without downloading it first."""
     mock_df = pd.DataFrame({"wavelength": [1, 2, 3]})
 
-    with patch("pathlib.Path.exists", return_value=file_exists) as mock_exists:
+    with patch("pathlib.Path.exists", return_value=file_exists):
         # Set up additional mocks based on whether download is expected
         if file_exists:
             # Simple case: file exists, just mock pandas.read_excel

--- a/roman_photoz/tests/test_logger.py
+++ b/roman_photoz/tests/test_logger.py
@@ -37,9 +37,9 @@ def test_setup_logging_sets_correct_level(log_level, level_name):
 
     # Test the specified log level
     logger = setup_logging(level=log_level)
-    assert logger.level == log_level, (
-        f"Logger level should be {level_name} ({log_level})"
-    )
+    assert (
+        logger.level == log_level
+    ), f"Logger level should be {level_name} ({log_level})"
 
 
 def test_setup_logging_creates_handler():

--- a/roman_photoz/tests/test_roman_catalog_process.py
+++ b/roman_photoz/tests/test_roman_catalog_process.py
@@ -1,5 +1,5 @@
-from unittest.mock import MagicMock, patch
 import os
+from unittest.mock import MagicMock, patch
 
 import pytest
 from astropy.table import Table
@@ -164,25 +164,48 @@ class TestRomanCatalogProcess:
         "model_filename, env_settings, expected_dirname",
         [
             # Test with default filename and different INFORMER_MODEL_PATH values
-            ("roman_model.pkl", {"INFORMER_MODEL_PATH": "/mock/informer/model/path"}, "/mock/informer/model/path"),
-            ("roman_model.pkl", {"INFORMER_MODEL_PATH": "/another/mock/path"}, "/another/mock/path"),
-            
+            (
+                "roman_model.pkl",
+                {"INFORMER_MODEL_PATH": "/mock/informer/model/path"},
+                "/mock/informer/model/path",
+            ),
+            (
+                "roman_model.pkl",
+                {"INFORMER_MODEL_PATH": "/another/mock/path"},
+                "/another/mock/path",
+            ),
             # Test with custom filenames and different INFORMER_MODEL_PATH values
-            ("custom_model.pkl", {"INFORMER_MODEL_PATH": "/mock/informer/model/path"}, "/mock/informer/model/path"),
-            ("special_model.pkl", {"INFORMER_MODEL_PATH": "/another/mock/path"}, "/another/mock/path"),
-            
+            (
+                "custom_model.pkl",
+                {"INFORMER_MODEL_PATH": "/mock/informer/model/path"},
+                "/mock/informer/model/path",
+            ),
+            (
+                "special_model.pkl",
+                {"INFORMER_MODEL_PATH": "/another/mock/path"},
+                "/another/mock/path",
+            ),
             # Test fallback to LEPHAREWORK when INFORMER_MODEL_PATH is not set
-            ("roman_model.pkl", {"LEPHAREWORK": "/lepharework/path"}, "/lepharework/path"),
-            ("custom_model.pkl", {"LEPHAREWORK": "/lepharework/path"}, "/lepharework/path"),
-            
+            (
+                "roman_model.pkl",
+                {"LEPHAREWORK": "/lepharework/path"},
+                "/lepharework/path",
+            ),
+            (
+                "custom_model.pkl",
+                {"LEPHAREWORK": "/lepharework/path"},
+                "/lepharework/path",
+            ),
             # Test default behavior when neither env var is set (empty path)
             ("roman_model.pkl", {}, ""),
             ("custom_model.pkl", {}, ""),
         ],
     )
-    def test_informer_model_path(self, monkeypatch, model_filename, env_settings, expected_dirname):
+    def test_informer_model_path(
+        self, monkeypatch, model_filename, env_settings, expected_dirname
+    ):
         """Test that informer_model_path property correctly combines path and filename.
-        
+
         The test verifies:
         1. Correct use of INFORMER_MODEL_PATH when set
         2. Fallback to LEPHAREWORK when INFORMER_MODEL_PATH is not set
@@ -194,27 +217,33 @@ class TestRomanCatalogProcess:
             if var in os.environ:
                 original_env[var] = os.environ[var]
                 monkeypatch.delenv(var)
-        
+
         try:
             # Set environment variables according to test case
             for var, value in env_settings.items():
                 monkeypatch.setenv(var, value)
-            
+
             # Initialize RomanCatalogProcess with the test model filename
             rcp = RomanCatalogProcess(model_filename=model_filename)
-            
+
             # Check both components of the path
             expected_path = os.path.join(expected_dirname, model_filename)
-            assert rcp.informer_model_path == expected_path, f"Full path does not match. Expected: {expected_path}"
-            
+            assert (
+                rcp.informer_model_path == expected_path
+            ), f"Full path does not match. Expected: {expected_path}"
+
             # Verify the directory part matches expected_dirname
             path_dirname = os.path.dirname(rcp.informer_model_path)
-            assert path_dirname == expected_dirname, f"Directory part does not match. Expected: {expected_dirname}"
-            
+            assert (
+                path_dirname == expected_dirname
+            ), f"Directory part does not match. Expected: {expected_dirname}"
+
             # Verify the filename part matches model_filename
             path_basename = os.path.basename(rcp.informer_model_path)
-            assert path_basename == model_filename, f"Filename part does not match. Expected: {model_filename}"
-            
+            assert (
+                path_basename == model_filename
+            ), f"Filename part does not match. Expected: {model_filename}"
+
         finally:
             # Restore original environment variables
             for var in ["INFORMER_MODEL_PATH", "LEPHAREWORK"]:

--- a/roman_photoz/tests/test_roman_catalog_process.py
+++ b/roman_photoz/tests/test_roman_catalog_process.py
@@ -1,4 +1,5 @@
 from unittest.mock import MagicMock, patch
+import os
 
 import pytest
 from astropy.table import Table
@@ -158,3 +159,66 @@ class TestRomanCatalogProcess:
 
         # Verify create_estimator_stage was always called
         mock_create_estimator.assert_called_once()
+
+    @pytest.mark.parametrize(
+        "model_filename, env_settings, expected_dirname",
+        [
+            # Test with default filename and different INFORMER_MODEL_PATH values
+            ("roman_model.pkl", {"INFORMER_MODEL_PATH": "/mock/informer/model/path"}, "/mock/informer/model/path"),
+            ("roman_model.pkl", {"INFORMER_MODEL_PATH": "/another/mock/path"}, "/another/mock/path"),
+            
+            # Test with custom filenames and different INFORMER_MODEL_PATH values
+            ("custom_model.pkl", {"INFORMER_MODEL_PATH": "/mock/informer/model/path"}, "/mock/informer/model/path"),
+            ("special_model.pkl", {"INFORMER_MODEL_PATH": "/another/mock/path"}, "/another/mock/path"),
+            
+            # Test fallback to LEPHAREWORK when INFORMER_MODEL_PATH is not set
+            ("roman_model.pkl", {"LEPHAREWORK": "/lepharework/path"}, "/lepharework/path"),
+            ("custom_model.pkl", {"LEPHAREWORK": "/lepharework/path"}, "/lepharework/path"),
+            
+            # Test default behavior when neither env var is set (empty path)
+            ("roman_model.pkl", {}, ""),
+            ("custom_model.pkl", {}, ""),
+        ],
+    )
+    def test_informer_model_path(self, monkeypatch, model_filename, env_settings, expected_dirname):
+        """Test that informer_model_path property correctly combines path and filename.
+        
+        The test verifies:
+        1. Correct use of INFORMER_MODEL_PATH when set
+        2. Fallback to LEPHAREWORK when INFORMER_MODEL_PATH is not set
+        3. Proper path combination with different model filenames
+        """
+        # Save original environment variables
+        original_env = {}
+        for var in ["INFORMER_MODEL_PATH", "LEPHAREWORK"]:
+            if var in os.environ:
+                original_env[var] = os.environ[var]
+                monkeypatch.delenv(var)
+        
+        try:
+            # Set environment variables according to test case
+            for var, value in env_settings.items():
+                monkeypatch.setenv(var, value)
+            
+            # Initialize RomanCatalogProcess with the test model filename
+            rcp = RomanCatalogProcess(model_filename=model_filename)
+            
+            # Check both components of the path
+            expected_path = os.path.join(expected_dirname, model_filename)
+            assert rcp.informer_model_path == expected_path, f"Full path does not match. Expected: {expected_path}"
+            
+            # Verify the directory part matches expected_dirname
+            path_dirname = os.path.dirname(rcp.informer_model_path)
+            assert path_dirname == expected_dirname, f"Directory part does not match. Expected: {expected_dirname}"
+            
+            # Verify the filename part matches model_filename
+            path_basename = os.path.basename(rcp.informer_model_path)
+            assert path_basename == model_filename, f"Filename part does not match. Expected: {model_filename}"
+            
+        finally:
+            # Restore original environment variables
+            for var in ["INFORMER_MODEL_PATH", "LEPHAREWORK"]:
+                if var in original_env:
+                    monkeypatch.setenv(var, original_env[var])
+                elif var in os.environ:
+                    monkeypatch.delenv(var)


### PR DESCRIPTION
Resolves [RCAL-1075](https://jira.stsci.edu/browse/RCAL-1075)

This PR refactors `roman_catalog_process.py` to allow the user to provide the path and filename to the pickle model (created by `RomanCatalogProcess.create_informer_stage()`).

The **optional** path to the model is provided as an environment variable named `INFORMER_MODEL_PATH` (otherwise it defaults to `LEPHAREWORK`), whereas the **optional** model filename is provided through the `model_filename` keyword argument during the class instantiation (if not provided, it defaults to `roman_model.pkl`).
