### PR TITLE
Use correct filter names in update_romanisim_catalog_fluxes

### DIFF
--- a/scripts/update_romanisim_catalog_fluxes.py
+++ b/scripts/update_romanisim_catalog_fluxes.py
@@ -13,9 +13,12 @@ def create_random_catalog(table: Table, n: int, seed: int = 13):
     return table[idx]
 
 
-def update_fluxes(target_catalog: Table, flux_catalog: Table) -> Table:
+def njy_to_mgy(flux):
     zero_point_flux = u.zero_point_flux(3631 * u.Jy)  # 1 maggy = 3631 Jy
+    return flux.to(u.mgy, zero_point_flux)
 
+
+def update_fluxes(target_catalog: Table, flux_catalog: Table) -> Table:
     fudge_factor = 100
     # LePhare catalog magnitudes seem to peak out at an absolute galaxy magnitude of -15
     # or so, while an L* galaxy should be more like -21.
@@ -24,15 +27,14 @@ def update_fluxes(target_catalog: Table, flux_catalog: Table) -> Table:
 
     for colname in target_catalog.colnames:
         if colname not in ['F062', 'F087', 'F106', 'F129',
-                           'F154', 'F187', 'F213', 'F146']:
+                           'F158', 'F184', 'F213', 'F146']:
             continue
         fluxname = f'segment_{colname.lower()}_flux'
         # convert from nJy (Roman  to maggies (romanisim_input_catalog)
-        target_catalog[colname] = (flux_catalog[fluxname]).to(
-            u.mgy, zero_point_flux
-        ) * fudge_factor
+        target_catalog[colname] = (
+            njy_to_mgy(flux_catalog[fluxname]) * fudge_factor)
 
-    # add source ID from roman_simulated_catalog
+    # Add source ID from roman_simulated_catalog
     target_catalog["label"] = flux_catalog["label"]
     target_catalog["ztrue"] = flux_catalog["ztrue"]
 
@@ -96,7 +98,7 @@ if __name__ == "__main__":
     # trim anything that is impossibly bright or faint
     # ugly here that we have a lot of different kinds of magnitudes now
     minmag = np.min(
-        [-2.5*np.log10(rpz_cat[x])
+        [-2.5*np.log10(njy_to_mgy(rpz_cat[x]).value)
          for x in rpz_cat.dtype.names
          if x.endswith('_flux') and x.startswith('segment')], axis=0)
     rpz_cat = rpz_cat[(minmag > 0) & (minmag < 33)]

--- a/scripts/update_romanisim_catalog_fluxes.py
+++ b/scripts/update_romanisim_catalog_fluxes.py
@@ -36,7 +36,7 @@ def update_fluxes(target_catalog: Table, flux_catalog: Table) -> Table:
 
     # Add source ID from roman_simulated_catalog
     target_catalog["label"] = flux_catalog["label"]
-    target_catalog["ztrue"] = flux_catalog["ztrue"]
+    target_catalog["redshift_true"] = flux_catalog["redshift_true"]
 
     return target_catalog
 


### PR DESCRIPTION
When doing the updates to update_romanisim_catalog_fluxes to use the new segment column names rather than the original magnitudeF000 names I messed up my listing of the filter names.  This led the code to simulate the "real" galaxy colors in 4 of the 6 filters but use the original "random" fluxes for the remaining two bands.  This PR fixes that issue.

It also changes the name of the true redshift to "redshift_true" from "ztrue" to match the corresponding rail/lephare name changes.