### PR TITLE
Process a simulated Roman catalog if no input filename is provided to roman-photoz

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,4 +130,3 @@ output = "coverage.xml"
 [project.scripts]
 roman-photoz = "roman_photoz.__main__:main"
 roman-photoz-create-simulated-catalog = "roman_photoz.create_simulated_catalog:main"
-roman-photoz-create-simulated-catalog-old = "roman_photoz.create_simulated_catalog_old:main"

--- a/roman_photoz/create_roman_filters.py
+++ b/roman_photoz/create_roman_filters.py
@@ -1,8 +1,7 @@
+import argparse
 import os
-import sys
 from importlib import resources
 from pathlib import Path
-import argparse
 
 import numpy as np
 import pandas as pd
@@ -231,13 +230,10 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description="Process a file containing the monochromatic effective area of each filter per column and create output files for each filter as well as the merged file for rail+lephare."
     )
-    parser.add_argument(
-        "input_path",
-        help="Path where the results will be saved."
-    )
+    parser.add_argument("input_path", help="Path where the results will be saved.")
     parser.add_argument(
         "input_filename",
-        help="Filename containing the monochromatic effective area data."
+        help="Filename containing the monochromatic effective area data.",
     )
     args = parser.parse_args()
 

--- a/roman_photoz/create_simulated_catalog.py
+++ b/roman_photoz/create_simulated_catalog.py
@@ -456,37 +456,37 @@ class SimulatedCatalog:
         logger.info("DONE")
 
 
-def main():
-    def parse_args():
-        parser = argparse.ArgumentParser(
-            description="Create a simulated catalog using the Roman telescope data."
-        )
-        parser.add_argument(
-            "--output-path",
-            type=str,
-            default=LEPHAREWORK,
-            help="Path to save the output catalog.",
-        )
-        parser.add_argument(
-            "--output-filename",
-            type=str,
-            default=DEFAULT_OUTPUT_CATALOG_FILENAME,
-            help="Filename for the output catalog.",
-        )
-        parser.add_argument(
-            "--nobj",
-            type=int,
-            default=-1,
-            help="Number of objects to create.",
-        )
-        parser.add_argument(
-            "--mag-noise", type=float, default=0, help="Add noise to the measurements."
-        )
+def parse_args(args=None):
+    parser = argparse.ArgumentParser(
+        description="Create a simulated catalog using the Roman telescope data."
+    )
+    parser.add_argument(
+        "--output-path",
+        type=str,
+        default=LEPHAREWORK,
+        help="Path to save the output catalog.",
+    )
+    parser.add_argument(
+        "--output-filename",
+        type=str,
+        default=DEFAULT_OUTPUT_CATALOG_FILENAME,
+        help="Filename for the output catalog.",
+    )
+    parser.add_argument(
+        "--nobj",
+        type=int,
+        default=-1,
+        help="Number of objects to create.",
+    )
+    parser.add_argument(
+        "--mag-noise", type=float, default=0, help="Add noise to the measurements."
+    )
 
-        return parser.parse_args()
+    return parser.parse_args(args)
 
-    args = parse_args()
 
+def main(args=None):
+    args = parse_args(args)
     logger.info("Starting simulated catalog creation...")
     rcp = SimulatedCatalog(args.nobj, mag_noise=args.mag_noise)
     rcp.process(args.output_path, args.output_filename)

--- a/roman_photoz/roman_catalog_process.py
+++ b/roman_photoz/roman_catalog_process.py
@@ -16,6 +16,7 @@ from astropy.table import Table
 from rail.core.stage import RailStage
 from rail.estimation.algos.lephare import LephareEstimator, LephareInformer
 
+from roman_photoz import create_simulated_catalog
 from roman_photoz.default_config_file import default_roman_config
 from roman_photoz.logger import logger
 from roman_photoz.roman_catalog_handler import RomanCatalogHandler
@@ -26,6 +27,10 @@ DS.__class__.allow_overwrite = True
 
 LEPHAREDIR = Path(os.environ.get("LEPHAREDIR", lp.LEPHAREDIR))
 LEPHAREWORK = os.environ.get("LEPHAREWORK", (LEPHAREDIR / "work").as_posix())
+CWD = Path.cwd().as_posix()
+DEFAULT_OUTPUT_CATALOG_FILENAME = (
+    create_simulated_catalog.DEFAULT_OUTPUT_CATALOG_FILENAME
+)
 
 # default paths and filenames
 DEFAULT_OUTPUT_KEYWORDS = Path(
@@ -450,6 +455,23 @@ def main():
 
     parser = _get_parser()
     args = parser.parse_args()
+
+    if args.input_filename is None:
+        logger.info(
+            "Input filename not provided; creating a simulated multiband Roman catalog..."
+        )
+        # call roman_create_simulated_catalog
+        args.input_filename = Path(CWD, DEFAULT_OUTPUT_CATALOG_FILENAME).as_posix()
+        create_simulated_catalog.main(
+            [
+                "--output-path",
+                CWD,
+                "--output-filename",
+                DEFAULT_OUTPUT_CATALOG_FILENAME,
+                "--nobj",
+                "1000",
+            ]
+        )
 
     logger.info("Starting Roman catalog processing")
     rcp = RomanCatalogProcess(

--- a/scripts/update_romanisim_catalog_fluxes.py
+++ b/scripts/update_romanisim_catalog_fluxes.py
@@ -39,8 +39,7 @@ def update_fluxes(target_catalog: Table, flux_catalog: Table) -> Table:
             continue
         fluxname = f"segment_{colname.lower()}_flux"
         # convert from nJy (Roman  to maggies (romanisim_input_catalog)
-        target_catalog[colname] = (
-            njy_to_mgy(flux_catalog[fluxname]) * fudge_factor)
+        target_catalog[colname] = njy_to_mgy(flux_catalog[fluxname]) * fudge_factor
 
     # Add source ID from roman_simulated_catalog
     target_catalog["label"] = flux_catalog["label"]


### PR DESCRIPTION
This PR allows the user to just run `roman-photoz` to process a multiband Roman catalog and save the results in the local folder (instead of LEPHAREWORK) with the default output filename "roman_simulated_catalog.parquet" (it will be overwritten/updated by the final result from roman-photoz).

A few style check fixes are also being applied.
