### PR TITLE
Decrease simulated catalog size for test efficiency

### DIFF
--- a/roman_photoz/regtest/test_integration.py
+++ b/roman_photoz/regtest/test_integration.py
@@ -27,7 +27,7 @@ def roman_catalog_process():
 
 def test_roman_photoz(tmp_path, dms_logger):
     # create catalog
-    sc = create_simulated_catalog.SimulatedCatalog(nobj=10000, mag_noise=0.02)
+    sc = create_simulated_catalog.SimulatedCatalog(nobj=1000, mag_noise=0.02)
     sc.process(tmp_path, "cat.parquet")
 
     # create instance


### PR DESCRIPTION
Reduced the number of objects in the simulated catalog from 10000 to 1000 for testing to see if it fixes the memory issue reported [here](https://github.com/spacetelescope/roman_photoz/pull/36).