### PR TITLE
[SCSB-225] migrate `[tool.pytest.ini_options]` to native TOML

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ pyrightconfig.json
 roman_photoz.egg-info/
 .tox/
 .env
+
+roman_photoz.log

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ docs = [
   "myst_parser",
 ]
 test = [
-  "pytest >=8.0.0",
+  "pytest>=9.0",
   "pytest-cov",
   "romancal",          # needed by conftest.py
   "coverage",          # used in GitHub Actions
@@ -71,8 +71,8 @@ zip-safe = false
   "**/*.asdf",
 ]
 
-[tool.pytest.ini_options]
-minversion = "4.6"
+[tool.pytest]
+minversion = "9.0"
 filterwarnings = ["error::ResourceWarning"]
 junit_family = "xunit2"
 log_cli_level = "info"


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Resolves [SCSB-225](https://jira.stsci.edu/browse/SCSB-225)

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->

Pytest 9.0 includes a native TOML table `[tool.pytest]`, which we should use instead of `[tool.pytest.ini_options]`