### PR TITLE
RCAL-1327 (2/3): Data Model & Column Standardization

### DIFF
--- a/roman_photoz/create_simulated_catalog.py
+++ b/roman_photoz/create_simulated_catalog.py
@@ -56,7 +56,7 @@ class SimulatedCatalog:
         Placeholder for simulated data.
     """
 
-    def __init__(self, nobj: int = 1000, mag_noise: float = 0.1):
+    def __init__(self, nobj: int = 1000, mag_noise: float = 0.1, seed=None):
         """
         Initializes the SimulatedCatalog class.
         """
@@ -73,6 +73,7 @@ class SimulatedCatalog:
         self._roman_catalog_template = self._read_roman_template_catalog()
         self.filter_list = get_roman_filter_list()
         self.mag_noise = mag_noise
+        self.seed = seed
 
     def _create_column_names(self):
         colnames_list = []
@@ -196,6 +197,7 @@ class SimulatedCatalog:
         output_filename: str = DEFAULT_OUTPUT_CATALOG_FILENAME,
         output_path: str = "",
         return_catalog: bool = False,
+        seed=None,
     ):
         """
         Create a simulated input catalog from the simulated data.
@@ -456,7 +458,7 @@ class SimulatedCatalog:
                     f"Requested {num_lines} lines, but only {total_lines} lines are available."
                 )
 
-            rng = np.random.default_rng()
+            rng = np.random.default_rng(seed=self.seed)
             random_indices = rng.choice(total_lines, num_lines, replace=False)
             return self.simulated_data[random_indices]
         else:
@@ -530,12 +532,22 @@ def main():
             action="store_true",
             help="Refresh the lib_mag folder by regenerating the synthetic magnitudes.",
         )
+        parser.add_argument(
+            "--seed",
+            type=int,
+            default=None,
+            help="Seed for the random number generator used in picking random lines and adding noise (default: None).",
+        )
         return parser.parse_args()
 
     args = parse_args()
 
     logger.info("Starting simulated catalog creation...")
-    simulated_catalog = SimulatedCatalog(nobj=args.nobj, mag_noise=args.mag_noise)
+    simulated_catalog = SimulatedCatalog(
+        nobj=args.nobj,
+        mag_noise=args.mag_noise,
+        seed=args.seed,
+    )
     simulated_catalog.process(
         output_path=args.output_path,
         output_filename=args.output_filename,

--- a/roman_photoz/roman_catalog_process.py
+++ b/roman_photoz/roman_catalog_process.py
@@ -15,6 +15,7 @@ from asdf import AsdfFile
 from astropy.table import Table
 from rail.core import DataStore
 from rail.estimation.algos.lephare import LephareEstimator, LephareInformer
+from roman_datamodels import datamodels
 
 from roman_photoz.default_config_file import default_roman_config
 from roman_photoz.logger import logger
@@ -78,6 +79,10 @@ class RomanCatalogProcess:
         self.inform_stage = None
         self.estimated = None
         self.default_roman_output_keys = read_output_keys(DEFAULT_OUTPUT_KEYWORDS)
+
+        self.input_filename = None
+        self.output_filename = None
+        self.output_format = None
 
     def _set_config_file(self, config_filename: Union[dict, str] = ""):
         """
@@ -189,6 +194,7 @@ class RomanCatalogProcess:
             gal_config=gal_overrides,
             qso_config=qso_overrides,
         )
+
         self.inform_stage.inform(self.data)
 
     def _create_estimator_stage(self):
@@ -233,41 +239,48 @@ class RomanCatalogProcess:
 
     def _save_results(
         self,
-        output_filename: Optional[str] = None,
-        output_format: str = "parquet",
     ):
         """
         Save the results to the specified output file.
-
-        Parameters
-        ----------
-        output_filename : str, optional
-            Name of the output file.
-        output_format : str, optional
-            Format to save the results.
-            Supported formats are "parquet" (default) and "asdf".
 
         Raises
         ------
         ValueError
             If there are no results to save.
         """
-        if self.estimated is not None:
-            ancil_data = self.estimated.data.ancil
+
+        if self.output_filename is None:
+            logger.info("No output filename provided. Updating input file in place.")
+            self._update_input(self.input_filename, save_results=True)
+            self.output_filename = self.input_filename
+        elif self.output_filename is not None and self.output_format.lower() in [
+            "parquet",
+            "asdf",
+        ]:
+            if self.estimated is not None:
+                self._update_input(self.input_filename, save_results=False)
+            else:
+                logger.error("No results to save")
+                raise ValueError("No results to save.")
+
+            if self.output_format.lower() == "parquet":
+                import pyarrow.parquet as pq
+
+                pq.write_table(self.results, self.output_filename)
+            elif self.output_format.lower() == "asdf":
+                tree = {"roman_photoz_results": self.results.to_pydict()}
+                with AsdfFile(tree) as af:
+                    af.write_to(self.output_filename)
         else:
-            logger.error("No results to save")
-            raise ValueError("No results to save.")
+            logger.error(
+                f"Unsupported output format: {self.output_format}. Supported formats are 'parquet' and 'asdf'."
+            )
+            raise ValueError(
+                f"Unsupported output format: {self.output_format}. Supported formats are 'parquet' and 'asdf'."
+            )
+        logger.info(f"Results saved to {self.output_filename}.")
 
-        if output_format.lower() == "parquet":
-            ancil_data = Table(ancil_data)
-            ancil_data.write(output_filename, format="parquet", overwrite=True)
-        elif output_format.lower() == "asdf":
-            tree = {"roman_photoz_results": ancil_data}
-            with AsdfFile(tree) as af:
-                af.write_to(output_filename)
-        logger.info(f"Results saved to {output_filename}.")
-
-    def _update_input(self, input_filename):
+    def _update_input(self, input_filename, save_results=False):
         # TODO: this can be done with the Table class
         # directly; no need for pyarrow
         import pyarrow as pa
@@ -276,6 +289,9 @@ class RomanCatalogProcess:
         tab = pq.read_table(input_filename)
         tab_astro = Table.read(input_filename)
         meta = dict(tab.schema.metadata)
+
+        # Create a MultibandSourceCatalogModel instance to access RAD schema definitions
+        catalog_model = datamodels.MultibandSourceCatalogModel()
 
         namedict = {
             "photoz": "Z_BEST",
@@ -289,25 +305,36 @@ class RomanCatalogProcess:
             "photoz_sed": "MOD_BEST",
         }
         for newname, oldname in namedict.items():
+            # Get column definition from RAD schema
+            col_def = catalog_model.get_column_definition(newname)
+
+            # get unit and description from the column definition, if available
+            # (since all the photoz columns are unitless, we will just set unit to None for now)
+            description = col_def.get("description", "")
+
+            # Create PyArrow field with metadata
+            arr = pa.array(self.estimated.data.ancil[oldname])
+            field = pa.field(newname, arr.type, metadata={"description": description})
+
             if newname not in tab.column_names:
-                tab = tab.append_column(
-                    newname, pa.array(self.estimated.data.ancil[oldname])
-                )
+                tab = tab.append_column(field, arr)
             else:
-                tab = tab.set_column(
-                    tab.schema.get_field_index(newname),
-                    newname,
-                    pa.array(self.estimated.data.ancil[oldname]),
-                )
+                tab = tab.set_column(tab.schema.get_field_index(newname), field, arr)
+
+            # Also add to Astropy table with metadata
             tab_astro[newname] = self.estimated.data.ancil[oldname]
-            # annoying to duplicate this, but we add to the "real"
-            # parquet table and also the astropy version to get the
-            # right astropy metadata
+            tab_astro[newname].info.description = description
+
+            logger.info(
+                f"Applied RAD schema metadata to column '{newname}': "
+                f"description={description}"
+            )
 
         extra_astropy_metadata = astropy.table.meta.get_yaml_from_table(tab_astro)
         meta[b"table_meta_yaml"] = "\n".join(extra_astropy_metadata).encode("utf-8")
-        tab = tab.replace_schema_metadata(meta)
-        pq.write_table(tab, input_filename)
+        self.results = tab.replace_schema_metadata(meta)
+        if save_results:
+            pq.write_table(self.results, self.input_filename)
 
     def process(
         self,
@@ -334,8 +361,14 @@ class RomanCatalogProcess:
             The type of flux to use for fitting.
             Options are "psf" (default), "kron", "segment", or "aperture."
         """
+
+        self.input_filename = input_filename
+        if output_filename is not None:
+            self.output_filename = output_filename
+            self.output_format = output_format
+
         self.data = self._get_data(
-            input_filename=input_filename,
+            input_filename=self.input_filename,
             fit_colname=fit_colname,
             fit_err_colname=fit_err_colname,
         )
@@ -347,13 +380,7 @@ class RomanCatalogProcess:
             self._create_informer_stage()
         self._create_estimator_stage()
 
-        if output_filename is not None:
-            self._save_results(
-                output_filename=output_filename,
-                output_format=output_format,
-            )
-        else:
-            self._update_input(input_filename)
+        self._save_results()
 
     @property
     def informer_model_exists(self):

--- a/roman_photoz/tests/test_metadata_preservation.py
+++ b/roman_photoz/tests/test_metadata_preservation.py
@@ -1,0 +1,135 @@
+import pyarrow.parquet as pq
+from astropy.table import Table
+from roman_photoz.roman_catalog_process import RomanCatalogProcess
+from roman_photoz.create_simulated_catalog import SimulatedCatalog
+
+PHOTOZ_COLS = [
+    "photoz",
+    "photoz_gof",
+    "photoz_high68",
+    "photoz_high90",
+    "photoz_high99",
+    "photoz_low68",
+    "photoz_low90",
+    "photoz_low99",
+    "photoz_sed",
+]
+
+
+def extract_metadata(filename, backend):
+    if backend == "pyarrow":
+        tab = pq.read_table(filename)
+        schema = tab.schema
+        colnames = schema.names
+
+        def get_field(name):
+            return schema.field(name)
+
+        def get_unit(meta):
+            # return "None" if key is missing instead of "NOT FOUND"
+            if b"unit" not in meta:
+                return "None"
+            return meta.get(b"unit").decode("utf-8")
+
+        def get_desc(meta):
+            return meta.get(b"description", b"NOT FOUND").decode("utf-8")
+    else:
+        tab = Table.read(filename)
+        colnames = tab.colnames
+
+        def get_field(name):
+            return tab[name]
+
+        def get_unit(col):
+            # since astropy .unit is now None, we stringify it to "None"
+            return str(col.unit)
+
+        def get_desc(col):
+            return col.info.description if col.info.description else "NOT FOUND"
+
+    metadata_dict = {}
+    for col_name in PHOTOZ_COLS:
+        if col_name in colnames:
+            field = get_field(col_name)
+            if backend == "pyarrow":
+                meta = field.metadata if field.metadata else {}
+                unit = get_unit(meta)
+                description = get_desc(meta)
+            else:
+                unit = get_unit(field)
+                description = get_desc(field)
+
+            # notice that a column is "found" if it has a description.
+            # (a unit is now allowed to be "None")
+            found = description != "NOT FOUND"
+            metadata_dict[col_name] = {
+                "unit": unit,
+                "description": description,
+                "found": found,
+            }
+        else:
+            metadata_dict[col_name] = {"found": False, "column_exists": False}
+    return metadata_dict
+
+
+def compare_metadata(pyarrow_meta, astropy_meta):
+    all_cols = set(pyarrow_meta.keys()) | set(astropy_meta.keys())
+    consistent = True
+    for col_name in sorted(all_cols):
+        pa_found = pyarrow_meta.get(col_name, {}).get("found", False)
+        astropy_found = astropy_meta.get(col_name, {}).get("found", False)
+
+        if pa_found and astropy_found:
+            pa_unit = pyarrow_meta[col_name]["unit"]
+            astropy_unit = astropy_meta[col_name]["unit"]
+
+            # Change: Simplified matching logic.
+            # Both should now naturally result in the string "None"
+            units_match = pa_unit == astropy_unit
+
+            desc_match = (
+                pyarrow_meta[col_name]["description"]
+                == astropy_meta[col_name]["description"]
+            )
+            if not (units_match and desc_match):
+                consistent = False
+        elif pa_found != astropy_found:
+            consistent = False
+        else:
+            # If both are not found, it's technically consistent (both missing)
+            pass
+
+    return consistent
+
+
+def test_metadata_preservation(tmp_path):
+    output_filename = "test_result.parquet"
+    simulated_catalog_filename = "simulated_catalog.parquet"
+
+    simulated_catalog = SimulatedCatalog(
+        nobj=100,
+        seed=42,
+    )
+    simulated_catalog.process(
+        output_path=tmp_path,
+        output_filename=simulated_catalog_filename,
+    )
+
+    # catalog processing
+    rcp = RomanCatalogProcess()
+    rcp.process(
+        input_filename=tmp_path / simulated_catalog_filename,
+        output_filename=tmp_path / output_filename,
+    )
+
+    pyarrow_meta = extract_metadata(tmp_path / output_filename, "pyarrow")
+    astropy_meta = extract_metadata(tmp_path / output_filename, "astropy")
+
+    pyarrow_count = sum(1 for m in pyarrow_meta.values() if m.get("found", False))
+    astropy_count = sum(1 for m in astropy_meta.values() if m.get("found", False))
+
+    consistent = compare_metadata(pyarrow_meta, astropy_meta)
+
+    assert pyarrow_count == 9, "Not all photoz columns have metadata in PyArrow"
+    assert astropy_count == 9, "Not all photoz columns have metadata in Astropy"
+    assert consistent, "Metadata is not consistent between PyArrow and Astropy"


### PR DESCRIPTION
## Part 2 of 3 — split from #58
**Depends on #59** (rebase onto `main` after #59 merges to see only the changes for this PR)

This PR integrates RAD schema metadata into the photo-z catalog processing pipeline.

### Changes
- Integrate `roman_datamodels.MultibandSourceCatalogModel` to fetch column definitions from the RAD schema
- Apply `description` metadata to all photoz columns via `get_column_definition()`
- Create PyArrow fields with embedded metadata for proper parquet serialization
- Propagate metadata to astropy Table columns for cross-format consistency
- Replace deprecated `RailStage.data_store` with direct `DataStore` access
- Refactor `_save_results` and `_update_input` for cleaner output handling
- Add `test_metadata_preservation.py` to verify metadata round-trips correctly across PyArrow and astropy
- Add seed parameter to SimulatedCatalog for reproducible simulations

### PR Stack
1. Infrastructure & Dependency Alignment (~#59~)
2. **This PR** — Data Model & Column Standardization
3. Simulation & Core Logic Updates (depends on this)

Resolves part of RCAL-1327 · Partially addresses #57

### Notes
- The errors in the CI jobs will be fixed once all the three PRs are merged.
- This description was generated by AI based on the changes.