### PR TITLE
[SCSB-273] freeze ruff rules with explicit selection

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,0 +1,17 @@
+line-length = 88
+
+[lint]
+select = [
+  "E4",
+  "E7",
+  "E9", # pycodestyle
+  "F",  # Pyflakes
+]
+extend-select = [
+  "NPY", # numpy specific
+]
+exclude = ["jdocs", ".tox", ".eggs", "build"]
+ignore = [
+  "E741", # ambiguous variable name
+  "F403", # unable to detect undefined names
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,17 +92,6 @@ line_length = 88
 line-length = 88
 force-exclude = "^/(\n  (\n      \\.eggs\n    | \\.git\n    | \\.pytest_cache\n    | \\.tox\n  )/\n)\n"
 
-[tool.ruff]
-line-length = 88
-
-[tool.ruff.lint]
-exclude = ["jdocs", ".tox", ".eggs", "build"]
-ignore = [
-  "E741", # ambiguous variable name
-  "F403", # unable to detect undefined names
-]
-extend-select = ["NPY"]
-
 [tool.cibuildwheel.macos]
 archs = ["x86_64", "arm64"]
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->

Resolves [SCSB-273](https://jira.stsci.edu/browse/SCSB-273)

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->

[`ruff 0.16.0` added a lot more default rules](https://astral.sh/blog/ruff-v0.16.0); to avoid a bunch of new Ruff failures, we can explicitly set the rules we're using with `select`. The pre-0.16.0 default rules were `select = ["E4", "E7", "E9", "F"]`

The new default rules for `ruff@1.6.0` are
```toml
select = [
  "YTT",  # flake8-2020
  "ASYNC",  # flake8-async
  "S",  # flake8-bandit
  "BLE",  # flake8-blind-except
  "B",  # flake8-bugbear
  "C4",  # flake8-comprehensions
  "DTZ",  # flake8-datetimez
  "T10",  # flake8-debugger
  "EXE",  # flake8-executable
  "FA",  # flake8-future-annotations
  "INT",  # flake8-gettext
  "ISC",  # flake8-implicit-str-concat
  "LOG",  # flake8-logging
  "G",  # flake8-logging-format
  "PIE",  # flake8-pie
  "PYI",  # flake8-pyi
  "PT",  # flake8-pytest-style
  "RET",  # flake8-return
  "SIM",  # flake8-simplify
  "TC",  # flake8-type-checking
  "PTH",  # flake8-use-pathlib
  "FLY",  # flynt
  "I",  # isort
  "N",  # pep8-naming
  "PERF",  # Perflint
  "E",  # pycodestyle
  "W",  # pycodestyle
  "D",  # pydocstyle
  "F",  # Pyflakes
  "PGH",  # pygrep-hooks
  "PL",  # Pylint
  "UP",  # pyupgrade
  "FURB",  # refurb
  "RUF",  # Ruff-specific rules
  "TRY",  # tryceratops
]
```