### PR TITLE
Add AI_POLICY.md to comply with STScI generative AI disclosure policy

### DIFF
--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -3,20 +3,20 @@
 STScI software maintainers welcome contributions, including those developed with the assistance of generative AI tools. However, the use of such tools does not change our expectations for contributor responsibility, engagement, or code quality. The following statements apply to all contributions. Pull requests that violate this policy will be closed.
 
 1. Prohibited Tools
-    1. Per STScI's AI policy, certain tools are prohibited and may not be used.  This currently includes, but may not be limited to, DeepSeek and Grammarly.
+   1. Per STScI's AI policy, certain tools are prohibited and may not be used. This currently includes, but may not be limited to, DeepSeek and Grammarly.
 
 2. Human ownership and accountability
-    1. Contributors are responsible for all submitted content, regardless of whether generative AI tools were used.
-    2. Contributors must understand and be able to explain all changes during review and address any concerns raised by maintainers.
-    3. Contributors are responsible for ensuring all submitted code complies with STScI licensing, regardless of whether generative AI tools were used.
+   1. Contributors are responsible for all submitted content, regardless of whether generative AI tools were used.
+   2. Contributors must understand and be able to explain all changes during review and address any concerns raised by maintainers.
+   3. Contributors are responsible for ensuring all submitted code complies with STScI licensing, regardless of whether generative AI tools were used.
 
 3. Disclosure
-    1. Presence of this `AI_POLICY.md` file indicates AI tools may have been used to assist with portions of this work.
-    2. Contributors are encouraged to apply a label of `ai-assisted` to pull requests that leveraged AI tools.
+   1. Presence of this `AI_POLICY.md` file indicates AI tools may have been used to assist with portions of this work.
+   2. Contributors are encouraged to apply a label of `ai-assisted` to pull requests that leveraged AI tools.
 
 4. Authentic engagement
-    1. The pull request process is collaborative and iterative. Contributors are expected to actively engage with reviewer feedback themselves. Copying and pasting replies to/from a generative AI tool does not count as engaging with the reviewer.
-    2. All pull requests must be reviewed by a human other than the contributor.
+   1. The pull request process is collaborative and iterative. Contributors are expected to actively engage with reviewer feedback themselves. Copying and pasting replies to/from a generative AI tool does not count as engaging with the reviewer.
+   2. All pull requests must be reviewed by a human other than the contributor.
 
 5. Consistency with repository conventions and existing style
-    1. In the context of Generative AI, this particularly means adhering to any linting standards as well as conveying information (comments, documentation, etc.) in a style the repository uses, and that is appropriate and to the point.
+   1. In the context of Generative AI, this particularly means adhering to any linting standards as well as conveying information (comments, documentation, etc.) in a style the repository uses, and that is appropriate and to the point.

--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -1,0 +1,22 @@
+# Usage of Generative AI
+
+STScI software maintainers welcome contributions, including those developed with the assistance of generative AI tools. However, the use of such tools does not change our expectations for contributor responsibility, engagement, or code quality. The following statements apply to all contributions. Pull requests that violate this policy will be closed.
+
+1. Prohibited Tools
+    1. Per STScI's AI policy, certain tools are prohibited and may not be used.  This currently includes, but may not be limited to, DeepSeek and Grammarly.
+
+2. Human ownership and accountability
+    1. Contributors are responsible for all submitted content, regardless of whether generative AI tools were used.
+    2. Contributors must understand and be able to explain all changes during review and address any concerns raised by maintainers.
+    3. Contributors are responsible for ensuring all submitted code complies with STScI licensing, regardless of whether generative AI tools were used.
+
+3. Disclosure
+    1. Presence of this `AI_POLICY.md` file indicates AI tools may have been used to assist with portions of this work.
+    2. Contributors are encouraged to apply a label of `ai-assisted` to pull requests that leveraged AI tools.
+
+4. Authentic engagement
+    1. The pull request process is collaborative and iterative. Contributors are expected to actively engage with reviewer feedback themselves. Copying and pasting replies to/from a generative AI tool does not count as engaging with the reviewer.
+    2. All pull requests must be reviewed by a human other than the contributor.
+
+5. Consistency with repository conventions and existing style
+    1. In the context of Generative AI, this particularly means adhering to any linting standards as well as conveying information (comments, documentation, etc.) in a style the repository uses, and that is appropriate and to the point.


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->

Resolves [RCAL-1431](https://jira.stsci.edu/browse/RCAL-1431)

Fixes spacetelescope/romancal#2403

This pull request introduces a new AI usage policy for contributors by adding an `AI_POLICY.md` file. The policy outlines expectations and rules regarding the use of generative AI tools in software contributions, emphasizing contributor responsibility, prohibited tools, disclosure, engagement, and adherence to repository standards.
