### PR TITLE
Make prebuilt LePhare models relocatable across hosts

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -60,13 +60,16 @@ the estimator, and verify that the required artifacts are present:
 
    ``roman-photoz`` also looks for an ``INFORMER_MODEL_PATH`` environment
    variable to determine where the informer model file (``roman_model.pkl``
-   by default) is read from/written to. It defaults to ``LEPHAREWORK`` if
-   not set, so you only need to set it explicitly if you want to read/store
-   the model somewhere else:
+   by default) is read from/written to. It may point either at the model
+   directory or directly at the pickle file. It defaults to ``LEPHAREWORK``
+   if not set, so you only need to set it explicitly if you want to
+   read/store the model somewhere else:
 
    .. code-block:: bash
 
       export INFORMER_MODEL_PATH=/path/to/model_dir
+      # or:
+      # export INFORMER_MODEL_PATH=/path/to/model_dir/roman_model.pkl
 
 2. Run:
 
@@ -87,6 +90,12 @@ the estimator, and verify that the required artifacts are present:
    can use in step 3 below if you don't have your own catalog yet (see
    "Creating a fresh simulated catalog" below for another option).
 
+   Setup also creates a sibling informer run directory at
+   ``dirname($LEPHAREWORK)/inform_roman``. That tree contains the SED
+   libraries used by estimation (for example ``lib_mag/QSO_COSMOS.doc``)
+   and must be packaged together with ``lephare_data`` and ``lephare_work``
+   when the assets are copied to another host.
+
    .. note::
 
      ``roman-photoz --setup`` only needs to be run **once** per
@@ -94,6 +103,23 @@ the estimator, and verify that the required artifacts are present:
      data and builds the informer model, which are then reused for all
      subsequent ``roman-photoz`` runs. There's no need to run it again unless
      you delete/change those directories.
+
+   .. note::
+
+     Relocatable packaging expects this layout (names can vary, sibling
+     relationship matters):
+
+     .. code-block:: text
+
+        package_root/
+          lephare_data/     # LEPHAREDIR
+          lephare_work/     # LEPHAREWORK, includes roman_model.pkl
+          inform_roman/     # informer run dir used by estimation
+
+     ``roman-photoz`` rewrites absolute host paths from ``roman_model.pkl``
+     at runtime and forces estimation to use the local ``inform_roman``
+     directory derived from ``LEPHAREWORK``. Still copy all three trees
+     together; ``lephare_work`` alone is not sufficient.
 
 3. Run ``roman-photoz``. Assuming there is a folder named ``OUTPUT`` in the
    current working directory where the updated catalog containing the

--- a/roman_photoz/roman_catalog_process.py
+++ b/roman_photoz/roman_catalog_process.py
@@ -2,6 +2,7 @@
 import argparse
 import json
 import os
+import pickle
 import tempfile
 from collections import OrderedDict
 from importlib.resources import files
@@ -26,11 +27,81 @@ DataStore.allow_overwrite = True
 
 LEPHAREDIR = Path(os.environ.get("LEPHAREDIR", lp.LEPHAREDIR))
 LEPHAREWORK = os.environ.get("LEPHAREWORK", (LEPHAREDIR / "work").as_posix())
+INFORMER_STAGE_NAME = "inform_roman"
 
 # default paths and filenames
 DEFAULT_OUTPUT_KEYWORDS = str(
     files(__package__ + ".data") / "default_roman_output.para"
 )
+
+
+def get_informer_run_dir(lepharework: Optional[str] = None) -> str:
+    """
+    Return the LePhare informer run directory for the current work tree.
+
+    RAIL's LephareInformer writes intermediate libraries under
+    ``dirname(LEPHAREWORK)/inform_roman``. Estimation must use that same
+    local path rather than any absolute ``run_dir`` baked into a relocated
+    model pickle.
+    """
+    work_dir = lepharework or os.environ.get("LEPHAREWORK", LEPHAREWORK)
+    return str(Path(work_dir).resolve().parent / INFORMER_STAGE_NAME)
+
+
+def _make_model_portable(model: dict, run_dir: str) -> dict:
+    """
+    Rewrite absolute paths stored in a LePhare model so it can be relocated.
+
+    Parameters
+    ----------
+    model : dict
+        Model dictionary loaded from ``roman_model.pkl``.
+    run_dir : str
+        Local informer run directory that should replace any baked-in path.
+        ``FILTER_REP`` is rewritten to ``$run_dir/filt`` because setup keeps
+        the compiled filter files there (and trims ``LEPHAREDIR/filt`` away).
+
+    Returns
+    -------
+    dict
+        Updated model dictionary.
+    """
+    portable = dict(model)
+    portable["run_dir"] = run_dir
+
+    lephare_config = portable.get("lephare_config")
+    if isinstance(lephare_config, dict):
+        portable_config = dict(lephare_config)
+        portable_config["FILTER_REP"] = str(Path(run_dir) / "filt")
+        # Always use the package PARA_OUT so relocated installs do not depend
+        # on the absolute source path captured during --setup.
+        portable_config["PARA_OUT"] = DEFAULT_OUTPUT_KEYWORDS
+        portable["lephare_config"] = portable_config
+
+    return portable
+
+
+def load_portable_informer_model(
+    model_path: str,
+    run_dir: Optional[str] = None,
+) -> dict:
+    """
+    Load an informer model pickle and rewrite non-portable absolute paths.
+
+    Purpose: allow prebuilt ``roman_model.pkl`` assets to be copied to a new
+    machine/directory (for example AWS) without retaining the original host
+    paths for ``run_dir``, ``FILTER_REP``, or ``PARA_OUT``.
+    """
+    with open(model_path, "rb") as handle:
+        model = pickle.load(handle)
+
+    if not isinstance(model, dict):
+        raise TypeError(
+            f"Expected informer model at {model_path} to be a dict, got {type(model)!r}"
+        )
+
+    resolved_run_dir = run_dir or get_informer_run_dir()
+    return _make_model_portable(model, run_dir=resolved_run_dir)
 
 
 class RomanCatalogProcess:
@@ -184,7 +255,7 @@ class RomanCatalogProcess:
         qso_stage_config = {f"qso.{k}": v for k, v in qso_overrides.items()}
 
         self.inform_stage = LephareInformer.make_stage(
-            name="inform_roman",
+            name=INFORMER_STAGE_NAME,
             nondetect_val=np.nan,
             model=self.informer_model_path,
             hdf5_groupname="",
@@ -214,7 +285,12 @@ class RomanCatalogProcess:
         # |we use rail's interface here to create the estimator stage
         # |https://rail-hub.readthedocs.io/en/latest/api/rail.estimation.estimator.html
         if self.informer_model_exists:
-            model = self.informer_model_path
+            # Rewrite absolute host paths from the pickle so relocated assets
+            # (S3/EFS copies, temp dirs, etc.) still resolve locally.
+            model = load_portable_informer_model(
+                self.informer_model_path,
+                run_dir=self.informer_run_dir,
+            )
         else:
             model = self.inform_stage.get_handle("model")
 
@@ -236,6 +312,9 @@ class RomanCatalogProcess:
             ref_band=self.flux_cols[0],
             output_keys=self.default_roman_output_keys,
             use_inform_offsets=False,
+            # Force the local informer tree instead of any absolute run_dir
+            # stored in a relocated model pickle.
+            run_dir=self.informer_run_dir,
             **{f"lephare.{k}": v for k, v in self.config.items()},
         )
 
@@ -405,12 +484,24 @@ class RomanCatalogProcess:
         return False
 
     @property
+    def informer_run_dir(self):
+        """
+        Local LePhare informer run directory used for estimation.
+
+        This is always derived from the current ``LEPHAREWORK`` location so a
+        relocated model pickle cannot force estimation back onto the original
+        absolute host path.
+        """
+        return get_informer_run_dir()
+
+    @property
     def informer_model_path(self):
         """
         Get the path to the informer model file used.
 
-        The path is determined by checking the INFORMER_MODEL_PATH environment variable first,
-        falling back to LEPHAREWORK if not set.
+        ``INFORMER_MODEL_PATH`` may be either the model file itself or the
+        directory containing it. When unset, ``LEPHAREWORK`` is used as the
+        model directory.
 
         Returns
         -------
@@ -420,7 +511,10 @@ class RomanCatalogProcess:
         informer_path = os.environ.get(
             "INFORMER_MODEL_PATH", os.environ.get("LEPHAREWORK", "")
         )
-        return Path(informer_path, self.model_filename).as_posix()
+        path = Path(informer_path)
+        if path.suffix == ".pkl" or path.name == self.model_filename:
+            return path.as_posix()
+        return (path / self.model_filename).as_posix()
 
 
 def _get_parser():
@@ -567,13 +661,14 @@ def run_setup(nobj: int = 1000, simulated_catalog_filename: str = "roman_photoz_
 
     # Remove stale informer artifacts to ensure a clean build. The model
     # pickle stores an absolute run_dir path from the original informer run;
-    # if it's stale, the estimator will look in the wrong place.
+    # if it's stale, the estimator will look in the wrong place unless the
+    # runtime path rewrite in load_portable_informer_model() is used.
     model_pickle = os.path.join(lepharework, "roman_model.pkl")
     if os.path.exists(model_pickle):
         logger.info(f"Removing stale model pickle: {model_pickle}")
         os.remove(model_pickle)
     # LephareInformer creates its run directory at $LEPHAREWORK/../inform_roman
-    informer_run_dir = os.path.join(os.path.dirname(lepharework), "inform_roman")
+    informer_run_dir = get_informer_run_dir(lepharework)
     if os.path.isdir(informer_run_dir):
         logger.info(f"Removing stale informer run directory: {informer_run_dir}")
         shutil.rmtree(informer_run_dir)
@@ -581,6 +676,20 @@ def run_setup(nobj: int = 1000, simulated_catalog_filename: str = "roman_photoz_
     logger.info("Running informer + estimator stage...")
     RomanCatalogProcess().process(input_filename=catalog_path)
     logger.info(f"Model written to: {model_pickle}")
+
+    # Rewrite absolute host paths in the published model so the three-tree
+    # package (lephare_data, lephare_work, inform_roman) can be relocated.
+    if os.path.exists(model_pickle):
+        portable_model = load_portable_informer_model(
+            model_pickle,
+            run_dir=informer_run_dir,
+        )
+        with open(model_pickle, "wb") as handle:
+            pickle.dump(portable_model, handle)
+        logger.info(
+            "Rewrote absolute paths in model pickle for relocatable packaging "
+            f"(run_dir={informer_run_dir})."
+        )
 
     logger.info("Removing intermediate files...")
     log_path = os.path.join(lepharework, "roman_photoz.log")
@@ -608,6 +717,8 @@ def run_setup(nobj: int = 1000, simulated_catalog_filename: str = "roman_photoz_
             os.path.join(lepharedir, "ext"),
             os.path.join(lepharedir, "alloutputkeys.txt"),
             model_pickle,
+            informer_run_dir,
+            os.path.join(informer_run_dir, "lib_mag"),
         )
         if not os.path.exists(path)
     ]
@@ -620,6 +731,7 @@ def run_setup(nobj: int = 1000, simulated_catalog_filename: str = "roman_photoz_
 
     logger.info("Setup complete.")
     logger.info(f"Model:       {model_pickle}")
+    logger.info(f"Informer:    {informer_run_dir}")
     logger.info(f"Catalog:     {catalog_path} (kept, reusable as an input catalog)")
     logger.info(f"LEPHAREDIR:  {lepharedir} (trimmed to estimator essentials)")
     logger.info(f"LEPHAREWORK: {lepharework}")

--- a/roman_photoz/tests/test_roman_catalog_process.py
+++ b/roman_photoz/tests/test_roman_catalog_process.py
@@ -1,11 +1,18 @@
 import os
+import pickle
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 from astropy.table import Table
 
 from roman_photoz.default_config_file import default_roman_config
-from roman_photoz.roman_catalog_process import RomanCatalogProcess
+from roman_photoz.roman_catalog_process import (
+    DEFAULT_OUTPUT_KEYWORDS,
+    RomanCatalogProcess,
+    get_informer_run_dir,
+    load_portable_informer_model,
+)
 
 
 @pytest.fixture
@@ -203,6 +210,12 @@ class TestRomanCatalogProcess:
                 {"INFORMER_MODEL_PATH": "/another/mock/path"},
                 "/another/mock/path",
             ),
+            # INFORMER_MODEL_PATH may point directly at the pickle file
+            (
+                "roman_model.pkl",
+                {"INFORMER_MODEL_PATH": "/mock/informer/model/path/roman_model.pkl"},
+                "/mock/informer/model/path",
+            ),
             # Test with custom filenames and different INFORMER_MODEL_PATH values
             (
                 "custom_model.pkl",
@@ -235,10 +248,14 @@ class TestRomanCatalogProcess:
     ):
         """Test that informer_model_path property correctly combines path and filename.
 
+        Purpose: ensure model path resolution supports both directory and file
+        values for INFORMER_MODEL_PATH, and falls back to LEPHAREWORK.
+
         The test verifies:
-        1. Correct use of INFORMER_MODEL_PATH when set
-        2. Fallback to LEPHAREWORK when INFORMER_MODEL_PATH is not set
-        3. Proper path combination with different model filenames
+        1. Correct use of INFORMER_MODEL_PATH when set to a directory
+        2. Correct use of INFORMER_MODEL_PATH when set to the pickle file itself
+        3. Fallback to LEPHAREWORK when INFORMER_MODEL_PATH is not set
+        4. Proper path combination with different model filenames
         """
         # Save original environment variables
         original_env = {}
@@ -281,6 +298,102 @@ class TestRomanCatalogProcess:
                 elif var in os.environ:
                     monkeypatch.delenv(var)
 
+    def test_informer_run_dir_follows_lepharework(self, monkeypatch, tmp_path):
+        """Purpose: estimation must use the local sibling inform_roman tree."""
+        lepharework = tmp_path / "package" / "lephare_work"
+        lepharework.mkdir(parents=True)
+        monkeypatch.setenv("LEPHAREWORK", str(lepharework))
+
+        rcp = RomanCatalogProcess(config_filename=default_roman_config)
+        expected = str((lepharework.parent / "inform_roman").resolve())
+        assert rcp.informer_run_dir == expected
+        assert get_informer_run_dir(str(lepharework)) == expected
+
+    def test_load_portable_informer_model_rewrites_absolute_paths(self, tmp_path):
+        """Purpose: relocated pickles must not retain the original host paths."""
+        model_path = tmp_path / "roman_model.pkl"
+        old_run_dir = "/System/Volumes/Data/grp/roman/old/inform_roman"
+        old_filter_rep = "/grp/roman/old/lephare_data/filt"
+        old_para_out = "/Users/someone/roman_photoz/roman_photoz/data/default_roman_output.para"
+        with open(model_path, "wb") as handle:
+            pickle.dump(
+                {
+                    "run_dir": old_run_dir,
+                    "lephare_config": {
+                        "FILTER_REP": old_filter_rep,
+                        "PARA_OUT": old_para_out,
+                        "Z_STEP": "0.04,0.,4.0",
+                    },
+                    "offsets": [0.0],
+                },
+                handle,
+            )
+
+        new_run_dir = str(tmp_path / "inform_roman")
+
+        portable = load_portable_informer_model(str(model_path), run_dir=new_run_dir)
+
+        assert portable["run_dir"] == new_run_dir
+        assert portable["lephare_config"]["FILTER_REP"] == str(
+            Path(new_run_dir) / "filt"
+        )
+        assert portable["lephare_config"]["PARA_OUT"] == DEFAULT_OUTPUT_KEYWORDS
+        assert portable["lephare_config"]["Z_STEP"] == "0.04,0.,4.0"
+        assert portable["offsets"] == [0.0]
+
+    @patch("roman_photoz.roman_catalog_process.LephareEstimator")
+    def test_create_estimator_stage_uses_portable_model_and_local_run_dir(
+        self, mock_estimator, tmp_path, monkeypatch
+    ):
+        """Purpose: estimator must ignore baked-in absolute run_dir paths."""
+        package_root = tmp_path / "assets"
+        lepharework = package_root / "lephare_work"
+        lepharedir = package_root / "lephare_data"
+        inform_roman = package_root / "inform_roman"
+        lepharework.mkdir(parents=True)
+        lepharedir.mkdir(parents=True)
+        inform_roman.mkdir(parents=True)
+
+        model_path = lepharework / "roman_model.pkl"
+        with open(model_path, "wb") as handle:
+            pickle.dump(
+                {
+                    "run_dir": "/System/Volumes/Data/grp/roman/old/inform_roman",
+                    "lephare_config": {
+                        "FILTER_REP": "/grp/roman/old/lephare_data/filt",
+                        "PARA_OUT": "/Users/old/default_roman_output.para",
+                        "Z_STEP": "0.04,0.,4.0",
+                    },
+                    "offsets": None,
+                },
+                handle,
+            )
+
+        monkeypatch.setenv("LEPHAREWORK", str(lepharework))
+        monkeypatch.setenv("LEPHAREDIR", str(lepharedir))
+        monkeypatch.setenv("INFORMER_MODEL_PATH", str(lepharework))
+
+        mock_stage = MagicMock()
+        mock_estimator.make_stage.return_value = mock_stage
+
+        rcp = RomanCatalogProcess(config_filename=default_roman_config)
+        rcp.flux_cols = ["segment_f158_flux"]
+        rcp.flux_err_cols = ["segment_f158_flux_err"]
+        rcp.data = Table()
+
+        rcp._create_estimator_stage()
+
+        call_kwargs = mock_estimator.make_stage.call_args.kwargs
+        expected_run_dir = str(inform_roman.resolve())
+        assert call_kwargs["run_dir"] == expected_run_dir
+
+        model = call_kwargs["model"]
+        assert isinstance(model, dict)
+        assert model["run_dir"] == expected_run_dir
+        assert model["lephare_config"]["FILTER_REP"] == str(Path(expected_run_dir) / "filt")
+        assert model["lephare_config"]["PARA_OUT"] == DEFAULT_OUTPUT_KEYWORDS
+        mock_stage.estimate.assert_called_once_with(rcp.data)
+
 
 class TestRunSetup:
     """Test class for the run_setup() bootstrap helper."""
@@ -290,14 +403,26 @@ class TestRunSetup:
         to find after the (mocked) download/build steps have "run"."""
         lepharedir = tmp_path / "lephare_data"
         lepharework = tmp_path / "lephare_work"
+        inform_roman = tmp_path / "inform_roman"
         (lepharedir / "opa").mkdir(parents=True)
         (lepharedir / "ext").mkdir(parents=True)
         (lepharedir / "vega").mkdir(parents=True)
         (lepharedir / "unused_dir").mkdir(parents=True)
         (lepharedir / "alloutputkeys.txt").write_text("")
         lepharework.mkdir(parents=True)
-        (lepharework / "roman_model.pkl").write_text("")
-        return lepharedir, lepharework
+        (inform_roman / "lib_mag").mkdir(parents=True)
+        with open(lepharework / "roman_model.pkl", "wb") as handle:
+            pickle.dump(
+                {
+                    "run_dir": "/old/host/inform_roman",
+                    "lephare_config": {
+                        "FILTER_REP": "/old/host/lephare_data/filt",
+                        "PARA_OUT": "/old/host/default_roman_output.para",
+                    },
+                },
+                handle,
+            )
+        return lepharedir, lepharework, inform_roman
 
     @patch("roman_photoz.roman_catalog_process.RomanCatalogProcess")
     @patch("roman_photoz.create_simulated_catalog.SimulatedCatalog")
@@ -316,7 +441,7 @@ class TestRunSetup:
         from roman_photoz import roman_catalog_process
         from roman_photoz.roman_catalog_process import run_setup
 
-        lepharedir, lepharework = self._make_lephare_assets(tmp_path)
+        lepharedir, lepharework, inform_roman = self._make_lephare_assets(tmp_path)
         monkeypatch.delenv("LEPHAREDIR", raising=False)
         monkeypatch.delenv("LEPHAREWORK", raising=False)
         monkeypatch.setattr(roman_catalog_process, "LEPHAREDIR", lepharedir)
@@ -334,7 +459,18 @@ class TestRunSetup:
         mock_rcp_class.return_value = mock_rcp
 
         def _fake_process(input_filename):
-            (lepharework / "roman_model.pkl").write_text("")
+            with open(lepharework / "roman_model.pkl", "wb") as handle:
+                pickle.dump(
+                    {
+                        "run_dir": "/old/host/inform_roman",
+                        "lephare_config": {
+                            "FILTER_REP": "/old/host/lephare_data/filt",
+                            "PARA_OUT": "/old/host/default_roman_output.para",
+                        },
+                    },
+                    handle,
+                )
+            (inform_roman / "lib_mag").mkdir(parents=True, exist_ok=True)
 
         mock_rcp.process.side_effect = _fake_process
 
@@ -347,6 +483,9 @@ class TestRunSetup:
         )
         # the simulated catalog is kept around for reuse, not deleted
         assert (lepharework / "catalog.parquet").exists()
+        with open(lepharework / "roman_model.pkl", "rb") as handle:
+            model = pickle.load(handle)
+        assert model["run_dir"] == str(inform_roman.resolve())
 
     @patch("roman_photoz.roman_catalog_process.RomanCatalogProcess")
     @patch("roman_photoz.create_simulated_catalog.SimulatedCatalog")
@@ -363,7 +502,7 @@ class TestRunSetup:
         build the model, trim LEPHAREDIR, and verify required assets exist."""
         from roman_photoz.roman_catalog_process import run_setup
 
-        lepharedir, lepharework = self._make_lephare_assets(tmp_path)
+        lepharedir, lepharework, inform_roman = self._make_lephare_assets(tmp_path)
         monkeypatch.setenv("LEPHAREDIR", str(lepharedir))
         monkeypatch.setenv("LEPHAREWORK", str(lepharework))
 
@@ -382,7 +521,18 @@ class TestRunSetup:
             # Simulate RomanCatalogProcess.process() (re-)creating the model
             # pickle after the stale one was removed by run_setup(), and
             # writing its log file alongside the catalog.
-            (lepharework / "roman_model.pkl").write_text("")
+            with open(lepharework / "roman_model.pkl", "wb") as handle:
+                pickle.dump(
+                    {
+                        "run_dir": "/old/host/inform_roman",
+                        "lephare_config": {
+                            "FILTER_REP": "/old/host/lephare_data/filt",
+                            "PARA_OUT": "/old/host/default_roman_output.para",
+                        },
+                    },
+                    handle,
+                )
+            (inform_roman / "lib_mag").mkdir(parents=True, exist_ok=True)
             (lepharework / "roman_photoz.log").write_text("")
 
         mock_rcp.process.side_effect = _fake_process
@@ -407,6 +557,16 @@ class TestRunSetup:
         # while the intermediate log file is removed
         assert os.path.exists(catalog_path)
         assert not os.path.exists(os.path.join(str(lepharework), "roman_photoz.log"))
+
+        # published model pickle is rewritten for relocatable packaging
+        with open(lepharework / "roman_model.pkl", "rb") as handle:
+            model = pickle.load(handle)
+        assert model["run_dir"] == str(inform_roman.resolve())
+        assert model["lephare_config"]["FILTER_REP"] == str(
+            Path(inform_roman.resolve()) / "filt"
+        )
+        assert model["lephare_config"]["PARA_OUT"] == DEFAULT_OUTPUT_KEYWORDS
+        assert (inform_roman / "lib_mag").exists()
 
         # LEPHAREDIR was trimmed to estimator essentials
         remaining = {p.name for p in lepharedir.iterdir()}


### PR DESCRIPTION
## Summary
- Fix estimation failures when prebuilt LePhare assets are copied to another host (e.g. AWS), where RAIL still followed absolute `run_dir` / `FILTER_REP` / `PARA_OUT` paths baked into `roman_model.pkl`.
- Force estimation to use the local `dirname(LEPHAREWORK)/inform_roman` tree, rewrite non-portable pickle paths at runtime, and accept `INFORMER_MODEL_PATH` as either a directory or the pickle file.
- Harden `--setup` packaging/verification and document the required three-tree layout (`lephare_data`, `lephare_work`, `inform_roman`).

## Test plan
- [x] `uv run python -m pytest roman_photoz/tests/test_roman_catalog_process.py -q` (24 passed)
- [ ] Copy packaged `lephare_data` / `lephare_work` / `inform_roman` to a temp dir with different absolute paths
- [ ] Set `LEPHAREDIR`, `LEPHAREWORK`, and `INFORMER_MODEL_PATH` to the copied locations
- [ ] Run `roman-photoz` on a catalog and confirm it no longer looks for `/System/Volumes/Data/grp/.../QSO_COSMOS.doc`

Co-Authored-By: Oz <oz-agent@warp.dev>