### PR TITLE
Test Python 3.13/3.14 and pin lephare 1.0.0rc0 in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,6 +26,16 @@ jobs:
   test:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@8c8bb6c6c962542921f993d47d26df38dccd50b1 # v3.0.2
     with:
+      # lephare 1.0.0rc0 has wheels for 3.11-3.13; 3.14 currently builds from
+      # source and needs OpenMP headers/libs (libomp-dev on Ubuntu).
+      libraries: |
+        apt:
+          - libomp-dev
       envs: |
         - linux: py311-xdist
         - linux: py312-xdist
+        - linux: py313-xdist
+        - linux: py314-xdist
+        - name: romancal[sdp] import smoke (latest Python)
+          linux: check-sdp
+          python-version: "3.14"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,16 +26,22 @@ jobs:
   test:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@8c8bb6c6c962542921f993d47d26df38dccd50b1 # v3.0.2
     with:
-      # lephare 1.0.0rc0 has wheels for 3.11-3.13; 3.14 currently builds from
-      # source and needs OpenMP headers/libs (libomp-dev on Ubuntu).
-      libraries: |
-        apt:
-          - libomp-dev
+      # Keep hangs from burning a full GHA timeout; unit jobs are ~5-10 min.
+      timeout-minutes: 45
       envs: |
+        # lephare 1.0.0rc0 ships cp311-cp313 wheels — no system OpenMP needed.
         - linux: py311-xdist
         - linux: py312-xdist
         - linux: py313-xdist
+        # 3.14 has no lephare 1.0.0rc0 wheel yet; build from source needs OpenMP.
+        # Scope apt to this job only: a global libomp-dev install raced/hung
+        # parallel runners for hours on the previous CI run.
         - linux: py314-xdist
-        - name: romancal[sdp] import smoke (latest Python)
+          libraries:
+            apt:
+              - libomp-dev
+        # SDP smoke on 3.13 (wheel path) validates romancal[sdp] without a
+        # source build of lephare.
+        - name: romancal[sdp] import smoke (Python 3.13)
           linux: check-sdp
-          python-version: "3.14"
+          python-version: "3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,9 @@ classifiers = [
 dependencies = [
   "asdf >=3.3.0",
   "astropy >=5.3.0",
+  # 1.0.0rc0 is the first 1.x series; pin lower bound for romancal#2369.
+  # Note: as of 1.0.0rc0, cp314 wheels are not published, so Python 3.14
+  # installs build lephare from source (needs OpenMP).
   "lephare >=1.0.0rc0",
   "numpy >=2.0",
   "pandas[excel]",
@@ -69,6 +72,9 @@ zip-safe = false
   "**/*.yaml",
   "**/*.json",
   "**/*.asdf",
+  "**/*.para",
+  "**/*.parquet",
+  "**/*.xlsx",
 ]
 
 [tool.pytest]

--- a/roman_photoz/tests/test_roman_catalog_process.py
+++ b/roman_photoz/tests/test_roman_catalog_process.py
@@ -1,7 +1,7 @@
 import os
 import pickle
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
 from astropy.table import Table
@@ -40,12 +40,20 @@ class TestRomanCatalogProcess:
         assert custom_model in rcp.informer_model_path
 
     @pytest.mark.parametrize("file_exists, expected", [(True, True), (False, False)])
-    @patch("os.path.exists")
-    def test_informer_model_exists(self, mock_path_exists, file_exists, expected):
-        """Test the informer_model_exists property with different file existence states"""
-        mock_path_exists.return_value = file_exists
+    def test_informer_model_exists(self, file_exists, expected):
+        """Test informer_model_exists for present and missing model files.
+
+        Purpose: ensure the property reflects whether the informer model path
+        exists, without globally mocking os.path.exists (which also breaks
+        package-data lookups during RomanCatalogProcess initialization).
+        """
         rcp = RomanCatalogProcess(config_filename=default_roman_config)
-        assert rcp.informer_model_exists is expected
+        with patch(
+            "roman_photoz.roman_catalog_process.os.path.exists",
+            return_value=file_exists,
+        ) as mock_path_exists:
+            assert rcp.informer_model_exists is expected
+            mock_path_exists.assert_called_with(rcp.informer_model_path)
 
     @patch("roman_photoz.roman_catalog_process.LephareInformer")
     def test_create_informer_stage_uses_correct_model(self, mock_informer):
@@ -157,7 +165,6 @@ class TestRomanCatalogProcess:
             ),  # When model exists, create_informer_stage should NOT be called
         ],
     )
-    @patch("os.path.exists")
     @patch(
         "roman_photoz.roman_catalog_process.RomanCatalogProcess._create_informer_stage"
     )
@@ -168,15 +175,16 @@ class TestRomanCatalogProcess:
         self,
         mock_create_estimator,
         mock_create_informer,
-        mock_exists,
         model_exists,
         should_create_informer,
     ):
-        """Test that the process method handles model existence correctly"""
-        # Setup mock to indicate model existence
-        mock_exists.return_value = model_exists
+        """Test that process() builds the informer only when the model is missing.
 
-        # Create RCP instance
+        Purpose: verify create_informer_stage is gated on informer_model_exists,
+        without mocking os.path.exists globally (package data must remain
+        readable during RomanCatalogProcess initialization).
+        """
+        # Create RCP instance before patching model existence
         rcp = RomanCatalogProcess(config_filename=default_roman_config)
 
         # Mock get_data and format_data
@@ -184,8 +192,14 @@ class TestRomanCatalogProcess:
         rcp._format_data = MagicMock()
         rcp._update_input = MagicMock()
 
-        # Call process method
-        rcp.process(input_filename="test")
+        with patch.object(
+            RomanCatalogProcess,
+            "informer_model_exists",
+            new_callable=PropertyMock,
+            return_value=model_exists,
+        ):
+            # Call process method
+            rcp.process(input_filename="test")
 
         # Verify create_informer_stage was called or not based on model existence
         if should_create_informer:

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,8 @@
 [tox]
 isolated_build = true
 env_list =
-    py3{,11,12,13}{,-alldeps,-devdeps}{,-pyargs,-warnings,-regtests,-cov,-webbpsf}{-nolegacypath}{,-xdist}
+    py3{,11,12,13,14}{,-alldeps,-devdeps}{,-pyargs,-warnings,-regtests,-cov,-webbpsf}{-nolegacypath}{,-xdist}
+    check-sdp
 
 [testenv]
 description =
@@ -34,6 +35,10 @@ deps =
     xdist: pytest-xdist
     ddtrace: ddtrace
     oldestdeps: minimum_dependencies
+    # Pin the lephare 1.0 release candidate under test for romancal#2369.
+    # Allow prereleases so the rc resolves under pip/tox.
+    lephare==1.0.0rc0
+pip_pre = true
 commands_pre =
     oldestdeps: minimum_dependencies romancal --filename requirements-min.txt
     oldestdeps: pip install -r requirements-min.txt
@@ -52,3 +57,14 @@ commands =
     nolegacypath: -p no:legacypath \
     webbpsf: --webbpsf \
     {posargs}
+
+[testenv:check-sdp]
+description =
+    smoke-import the romancal[sdp] stack used by DMS/ops installs
+skip_install = true
+pip_pre = true
+deps =
+    romancal[sdp]>=1.1.0
+    lephare==1.0.0rc0
+commands =
+    python -c "import importlib.metadata as m; import lephare, pysiaf, roman_photoz, romancal, stpreview, tables; print('romancal', m.version('romancal')); print('roman-photoz', m.version('roman-photoz')); print('lephare', m.version('lephare')); print('pysiaf', m.version('pysiaf')); print('stpreview', m.version('stpreview')); print('tables', m.version('tables'))"


### PR DESCRIPTION
## Summary
- Expand CI/tox through **Python 3.13 and 3.14** (photoz #63; romancal SDP/3.14 follow-up from #2185).
- Pin **`lephare==1.0.0rc0`** in tox/CI (`pip_pre = true`) to validate the 1.x RC (romancal #2369 / RCAL-1414).
- Add a **`check-sdp`** tox env + CI job that smoke-imports `romancal[sdp]` on **Python 3.13** (wheel path for lephare): `roman_photoz`, `pysiaf`, `stpreview`, `lephare`, `tables`.
- On **Python 3.14 only**, install **`libomp-dev`** so lephare 1.0.0rc0 can build from source (no cp314 wheels yet). Scoped per-job after a global apt install hung parallel runners for hours.
- Cap tox jobs at **45 minutes** so hangs fail fast.
- Fix over-broad `os.path.exists` mocks in `test_roman_catalog_process.py` that broke `RomanCatalogProcess` init when package data was present.
- Include `*.para` / `*.parquet` / `*.xlsx` in setuptools package-data globs.

## Verification
- Local (Python 3.14.7, Homebrew `libomp`, `lephare==1.0.0rc0`, `romancal==1.1.0`): unit suite green; fixed model-existence tests pass.
- CI on this branch: **py311–py314-xdist**, **romancal[sdp] smoke (3.13)**, build, pre-commit, RTD — green.

## Notes / known limitations
- `lephare==1.0.0rc0` has wheels for 3.11–3.13 only; **3.14 builds from source** until upstream ships cp314 wheels.
- SDP import smoke runs on **3.13** (stable binary path). py314 CI still exercises the photoz+lephare install/test path on 3.14.
- Does **not** run full LEPHARE e2e / romancal photoz regression tests (romancal #2186).
- Supersedes the stale approach in #56.

## Related
- Closes #63
- Related to spacetelescope/romancal#2369
- Related to spacetelescope/romancal#2185
- Related to spacetelescope/romancal#2186
